### PR TITLE
Fix MIME types

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,7 +34,6 @@ app.get('/cover', function(req, res) {
 
     var fetcher = new coce.CoceFetcher();
     fetcher.fetch(ids, providers, function(url) {
-        res.contentType("application/x-javascript");
         if ( req.query.all === undefined ) {
             // Not &all param: URL are picked up by provider priority order
             var ret = {};
@@ -45,7 +44,12 @@ app.get('/cover', function(req, res) {
                 }
             url = ret;
         }
-        if (callback) url = callback + '(' + JSON.stringify(url) + ')'
+        if (callback) {
+            res.contentType("application/javascript");
+            url = callback + '(' + JSON.stringify(url) + ')'
+        } else {
+            res.contentType("application/json");
+        }
         res.send(url);
     });
 });


### PR DESCRIPTION
We were using outdated experimental mimetypes in our response headers,
we to squelch these errors and use the current correct mime types.

I've set 'application/json' for the default response, and 'application/javascript'
for the jsonp response as per the rfc's.
