### PR TITLE
Errors should be returned as json bodies

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,7 +13,9 @@ var isbnRE = /([0-9X]{10,13})/;
 app.get('/cover', function(req, res) {
     var ids = req.query.id;
     if (ids === undefined || ids.length < 8) {
-        res.send("id parameter is missing");
+	var fail = {};
+	fail.error = "ID parameter is missing";
+        res.send(fail);
         return;
     }
     ids = ids.split(',');
@@ -27,7 +29,12 @@ app.get('/cover', function(req, res) {
         }
     }
     ids = idsNew;
-    if (ids.length === 0) { res.send('No id parameter'); return; }
+    if (ids.length === 0) { 
+	var fail = {};
+	fail.error = "Bad id parameter";
+	res.send(fail);
+	return;
+    }
     var providers = req.query.provider;
     providers = providers == undefined ? coce.config.providers : providers.split(',');
     var callback = req.query.callback;


### PR DESCRIPTION
For consistency with a successful response, an error response should
also be in json to allow for the same code in the client app to handle
both cases

closes #4
