### PR TITLE
Fix Amazon response when cover is not found

### DIFF
--- a/coce.js
+++ b/coce.js
@@ -64,7 +64,10 @@ CoceFetcher.prototype.aws = function awsFetcher(ids) {
     };
     https.get(opts, (res) => {
       const url = `https://${opts.hostname}${opts.path}`;
-      if (res.statusCode === 200 || res.statusCode === 403) repo.addurl('aws', id, url);
+      if (res.statusCode === 200 || res.statusCode === 403) {
+        // 43 bytes is the size of 1x1px gif returned by Amazon
+        if (res.headers['content-length'] !== '43') repo.addurl('aws', id, url);
+      }
       repo.increment();
       i += 1;
       // timeout for next request


### PR DESCRIPTION
By using provider "aws" in Coce, a result in JSON response is always returned whether cover image is found or not.

It seems Amazon is returning a 1x1 pixel gif when cover is not found. Looking at your aws fetcher I imagine it previously returned HTTP 404 or something similar, but now it returns a HTTP 200 and this 1x1 image when no cover is found.

To reproduce:

Make a request to Coce server:

http://coce.server/cover?id=0000000000&provider=aws

Observe response:

```{"0000000000":"https://images-na.ssl-images-amazon.com/images/P/0000000000.01.MZZZZZZZZZ.jpg"}```

Open the returned URL in your browser and observe 1x1 gif.

Expected response:

```{}```

As we use a HEAD request for `aws` I propose we examine Content-Length response header for 43 bytes that is the size of this 1x1 gif. If Content-Length is something else then we expect a cover was found and return URL in our response.