### PR TITLE
MediumSize to MediumImage

### DIFF
--- a/config.json.sample
+++ b/config.json.sample
@@ -16,7 +16,7 @@
   },
   "aws": {
     "timeout": 86400,
-    "imageSize": "MediumSize"
+    "imageSize": "MediumImage"
   },
   "ol": {
     "timeout": 86400,


### PR DESCRIPTION
I guess it should be `MediumImage`, right?

See: https://github.com/search?q=repo%3Afredericd%2Fcoce%20MediumImage&type=code